### PR TITLE
use _stat64() on MinGW

### DIFF
--- a/programs/util.h
+++ b/programs/util.h
@@ -141,7 +141,7 @@ UTIL_STATIC void UTIL_waitForNextTick(UTIL_time_t ticksPerSecond)
 /*-****************************************
 *  File functions
 ******************************************/
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || defined(__MINGW32__)
 	#define chmod _chmod
 	typedef struct _stat64 stat_t;
 #else
@@ -172,7 +172,7 @@ UTIL_STATIC int UTIL_setFileStat(const char *filename, stat_t *statbuf)
 UTIL_STATIC int UTIL_getFileStat(const char* infilename, stat_t *statbuf)
 {
     int r;
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || defined(__MINGW32__)
     r = _stat64(infilename, statbuf);
     if (r || !(statbuf->st_mode & S_IFREG)) return 0;   /* No good... */
 #else
@@ -186,7 +186,7 @@ UTIL_STATIC int UTIL_getFileStat(const char* infilename, stat_t *statbuf)
 UTIL_STATIC U64 UTIL_getFileSize(const char* infilename)
 {
     int r;
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || defined(__MINGW32__)
     struct _stat64 statbuf;
     r = _stat64(infilename, &statbuf);
     if (r || !(statbuf.st_mode & S_IFREG)) return 0;   /* No good... */
@@ -212,7 +212,7 @@ UTIL_STATIC U64 UTIL_getTotalFileSize(const char** fileNamesTable, unsigned nbFi
 UTIL_STATIC int UTIL_doesFileExists(const char* infilename)
 {
     int r;
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || defined(__MINGW32__)
     struct _stat64 statbuf;
     r = _stat64(infilename, &statbuf);
     if (r || !(statbuf.st_mode & S_IFREG)) return 0;   /* No good... */
@@ -228,7 +228,7 @@ UTIL_STATIC int UTIL_doesFileExists(const char* infilename)
 UTIL_STATIC U32 UTIL_isDirectory(const char* infilename)
 {
     int r;
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) || defined(__MINGW32__)
     struct _stat64 statbuf;
     r = _stat64(infilename, &statbuf);
     if (!r && (statbuf.st_mode & _S_IFDIR)) return 1;


### PR DESCRIPTION
On MinGW, use _stat64() and struct _stat64 instead of stat() and struct stat_t. This fixes reporting incorrect sizes for large files.